### PR TITLE
Fix OpenGL text rendering on Linux arm64

### DIFF
--- a/sourceCode/visual/oGL.cpp
+++ b/sourceCode/visual/oGL.cpp
@@ -1164,8 +1164,8 @@ void ogl::loadBitmapFont(const unsigned char* fontData,int fontHeight,int theFon
             temp[i]=0;
         int sizeX=fontData[p++];
         int sizeY=fontData[p++];
-        int originX=(char)fontData[p++];
-        int originY=(char)fontData[p++];
+        int originX=(signed char)fontData[p++];
+        int originY=(signed char)fontData[p++];
         int charWidth=fontData[p++];
 //      if (letter==int('e'))
     //      int aaa=0;


### PR DESCRIPTION
As part of the Robotics course at USI (Lugano, Switzerland) we have been using Coppelia in student labs and projects for a number of years. This year, we have been faced with a quite large number of students using Apple Silicon Macs, so we have invested some effort in getting the simulator to build and run under Ubuntu arm64 in a VM (and native macOS, but we use Linux with students because of other dependencies).

We would like to contribute back a couple of fixes for bugs that we encountered in the process. I'll start with this one, since it looks the most straightforward to me.

As you can see in the screenshot, text in the 3D scene and other parts of the GUI rendered through OpenGL is currently broken.
![MicrosoftTeams-image](https://user-images.githubusercontent.com/317661/230443920-2f229a06-cd20-4e11-84a9-386be936d59b.png)

I have tracked down the problem to the font-loading code in `oGL.cpp`, which depends on `char` being signed. Unlike most other platforms, Linux arm64 defines `char` as unsigned, so negative character origins (e.g. -1, -2) were overflowing to high positive values (255, 254, ...).

You can see here the text rendered correctly after applying the fix:
<img width="1512" alt="MicrosoftTeams-image (1)" src="https://user-images.githubusercontent.com/317661/230444789-843b3ae0-db58-45be-bbf7-e6fef1669a9c.png">

Cc: @Dario-Mantegazza @jeguzzi